### PR TITLE
More helpful error message when service account for CE is not found

### DIFF
--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -38,6 +38,10 @@ else
   COMMAND="gcloud iam service-accounts list \
     --format='value(email)' --filter='displayName:$SVC_ACCOUNT_NAME'"
   SVC_ACCOUNT=$(eval $COMMAND) # using eval here due to nested quotes and vars
+  if [ -z "$SVC_ACCOUNT" ]; then
+    echo "Default service account for Compute Engine not found, please create one first"
+    exit 1
+  fi
   echo "Found service account: $SVC_ACCOUNT"
 
   # If not, create one


### PR DESCRIPTION
When I tried to run setup script I faced error:
`ERROR: (gcloud.iam.service-accounts.keys.create) argument --iam-account: Bad value [client_secrets.json]: Not a valid service account identifier. It should be either a numeric string representing the unique_id or an email of the form: my-iam-account@somedomain.com or my-iam-account@PROJECT_ID.iam.gserviceaccount.com`

It was caused by the fact that SVC_ACCOUNT was empty because I never used CE on my Cloud account before. I think this error message would be more helpful as "activated CE" is not listed in requirements.